### PR TITLE
Update Python version notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See also:
 
 # Installation
 
-You need Python 3.6, 3.7, 3.8 or 3.9. Unfortunately, PyTorch does not support Python 3.10 yet.
+You need Python 3.6, 3.7, 3.8, 3.9, or 3.10. As of April 2023, PyTorch unfortunately does not support Python 3.11 yet, see pytorch/pytorch#86566.
 
 Some users have reported problems with Python installed from Microsoft Store. If you see an error:
 `ImportError: DLL load failed while importing fugashi: The specified module could not be found.`,


### PR DESCRIPTION
Currently, the README has outdated information regarding PyTorch's required Python version, saying that Python 3.10 isn't supported. However, it seems like PyTorch has now added support for 3.10. I have tested mokuro with Python 3.10.6 and it seems to work fine.

I've updated the required Python version note and linked to the tracking issue for Python 3.11 support pytorch/pytorch#86566 in case the information goes out of date.