### PR TITLE
Add webp to supported image types

### DIFF
--- a/mokuro/overlay_generator.py
+++ b/mokuro/overlay_generator.py
@@ -71,7 +71,7 @@ class OverlayGenerator:
             shutil.copy(STYLES_PATH, out_dir / 'styles.css')
             shutil.copy(PANZOOM_PATH, out_dir / 'panzoom.min.js')
 
-        img_paths = [p for p in path.glob('**/*') if p.is_file() and p.suffix.lower() in ('.jpg', '.jpeg', '.png')]
+        img_paths = [p for p in path.glob('**/*') if p.is_file() and p.suffix.lower() in ('.jpg', '.jpeg', '.png', '.webp')]
         img_paths = natsorted(img_paths)
 
         page_htmls = []


### PR DESCRIPTION
Webp files have better (lossless and lossy) compression and (de/en)coding times than pngs and jpgs.
I tested `manga_page_ocr.py` with a webp file, and it works. I didn't test with a animated webp yet, i assume it only do the OCR in the first frame, or crashes. I'll test it sometime soon.