### PR TITLE
Add InvalidImage and try-except to OverlayGenerator

### DIFF
--- a/mokuro/__init__.py
+++ b/mokuro/__init__.py
@@ -1,4 +1,4 @@
 __version__ = '0.1.7'
 
-from mokuro.manga_page_ocr import MangaPageOcr
+from mokuro.manga_page_ocr import MangaPageOcr, InvalidImage
 from mokuro.overlay_generator import OverlayGenerator

--- a/mokuro/manga_page_ocr.py
+++ b/mokuro/manga_page_ocr.py
@@ -10,6 +10,9 @@ from mokuro import __version__
 from mokuro.cache import cache
 from mokuro.utils import imread
 
+class InvalidImage(Exception):
+    def __init__(self, message = "Animation file, Corrupted file or Unsupported type"):
+        super().__init__(message)
 
 class MangaPageOcr:
     def __init__(self,
@@ -35,6 +38,8 @@ class MangaPageOcr:
 
     def __call__(self, img_path):
         img = imread(img_path)
+        if img is None:
+            raise InvalidImage()
         H, W, *_ = img.shape
         mask, mask_refined, blk_list = self.text_detector(img, refine_mode=1, keep_undetected_mask=True)
 

--- a/mokuro/overlay_generator.py
+++ b/mokuro/overlay_generator.py
@@ -82,7 +82,11 @@ class OverlayGenerator:
                 result = load_json(json_path)
             else:
                 self.init_models()
-                result = self.mpocr(img_path)
+                try:
+                    result = self.mpocr(img_path)
+                except Exception as e:
+                    logger.error(f'Failed OCR of file "{img_path}": {e}')
+                    continue
                 json_path.parent.mkdir(parents=True, exist_ok=True)
                 dump_json(result, json_path)
 


### PR DESCRIPTION
Making the overlay generator more error-resistant and a MangaPageOcr error more descriptive