### PR TITLE
Add dark mode

### DIFF
--- a/mokuro/overlay_generator.py
+++ b/mokuro/overlay_generator.py
@@ -260,6 +260,7 @@ class OverlayGenerator:
                 option_toggle('menuEditableText', 'editable text ')
                 option_select('menuFontSize', 'font size: ',
                               ['auto', 9, 10, 11, 12, 14, 16, 18, 20, 24, 32, 40, 48, 60])
+                option_toggle('menuDarkMode', 'dark mode')
                 option_toggle('menuEInkMode', 'e-ink mode ')
                 option_toggle('menuToggleOCRTextBoxes', 'toggle OCR text boxes on click')
                 option_color('menuBackgroundColor', 'background color', '#C4C3D0')

--- a/mokuro/script.js
+++ b/mokuro/script.js
@@ -21,9 +21,10 @@ let defaultState = {
     defaultZoomMode: "fit to screen",
     toggleOCRTextBoxes: false,
     backgroundColor: '#C4C3D0',
+    darkMode: false
 };
 
-let state = JSON.parse(JSON.stringify(defaultState));
+let state = { ...defaultState };
 
 function saveState() {
     localStorage.setItem(storageKey, JSON.stringify(state));
@@ -50,6 +51,7 @@ function updateUI() {
     document.getElementById("menuDisplayOCR").checked = state.displayOCR;
     document.getElementById('menuFontSize').value = state.fontSize;
     document.getElementById('menuEInkMode').checked = state.eInkMode;
+    document.getElementById('menuDarkMode').checked = state.darkMode;
     document.getElementById('menuDefaultZoom').value = state.defaultZoomMode;
     document.getElementById('menuToggleOCRTextBoxes').checked = state.toggleOCRTextBoxes;
     document.getElementById('menuBackgroundColor').value = state.backgroundColor;
@@ -170,6 +172,12 @@ function updateProperties() {
     if (state.backgroundColor) {
         r.style.setProperty('--colorBackground', state.backgroundColor)
     }
+
+    if (state.darkMode) {
+        pc.style.setProperty('filter', 'invert(1)');
+    } else {
+        pc.style.setProperty('filter', 'invert(0)');
+    }
 }
 
 document.getElementById('menuR2l').addEventListener('click', function () {
@@ -227,6 +235,12 @@ document.getElementById('menuToggleOCRTextBoxes').addEventListener('click', func
     saveState();
     updateProperties();
 }, false);
+
+document.getElementById('menuDarkMode').addEventListener('click', function () {
+    state.darkMode = document.getElementById('menuDarkMode').checked;
+    saveState();
+    updateProperties();
+});
 
 document.getElementById('menuBackgroundColor').addEventListener(
     'input',


### PR DESCRIPTION
Adds dark mode, accessible via the settings:

![image](https://github.com/kha-white/mokuro/assets/89428869/6b1a15ef-420c-48c9-806f-191d20286f3b)

Sample of what this looks like:

![image](https://github.com/kha-white/mokuro/assets/89428869/46c0e16c-c9c5-43ce-92c2-3caf70f96cb8)

Also, I took the liberty to change the `defaultState` clone from using the JSON functions to just doing a spread instead. Should be a harmless performance boost 😁.

