### PR TITLE
Support for processing AVIF images

### DIFF
--- a/mokuro/manga_page_ocr.py
+++ b/mokuro/manga_page_ocr.py
@@ -1,5 +1,7 @@
+import os
 import cv2
 import numpy as np
+import pillow_avif
 from PIL import Image
 from loguru import logger
 from scipy.signal.windows import gaussian
@@ -38,7 +40,18 @@ class MangaPageOcr:
             self.mocr = MangaOcr(pretrained_model_name_or_path, force_cpu)
 
     def __call__(self, img_path):
-        img = imread(img_path)
+        # Check if the file is in AVIF format
+        # Create a temporary JPEG path
+        img_path = str(img_path)
+        if img_path.lower().endswith('.avif'):
+            temp_path = img_path.replace('.avif', '_temp.jpg')
+            avif_img = Image.open(img_path)
+            avif_img.save(temp_path, 'JPEG')
+            img = imread(temp_path)
+            os.remove(temp_path)
+        else:
+            img = imread(img_path)
+
         if img is None:
             raise InvalidImage()
         H, W, *_ = img.shape

--- a/mokuro/overlay_generator.py
+++ b/mokuro/overlay_generator.py
@@ -73,7 +73,7 @@ class OverlayGenerator:
             shutil.copy(STYLES_PATH, out_dir / 'styles.css')
             shutil.copy(PANZOOM_PATH, out_dir / 'panzoom.min.js')
 
-        img_paths = [p for p in path.glob('**/*') if p.is_file() and p.suffix.lower() in ('.jpg', '.jpeg', '.png', '.webp')]
+        img_paths = [p for p in path.glob('**/*') if p.is_file() and p.suffix.lower() in ('.jpg', '.jpeg', '.png', '.webp', '.avif')]
         img_paths = natsorted(img_paths)
 
         page_htmls = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ natsort
 numpy
 opencv-python
 Pillow
+pillow-avif-plugin
 pyclipper
 pytest
 requests


### PR DESCRIPTION
### Support for processing AVIF images
I've noticed that many of the comics I've downloaded in recent years are in AVIF format, so I want to add support for this image format. Handling AVIF requires the pillow-avif-plugin module. The process involves creating a temporary JPG file for processing, which has been proven to work.