### PR TITLE
Follow XDG Base Directory Specification for cache location

### DIFF
--- a/mokuro/cache.py
+++ b/mokuro/cache.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import requests
@@ -6,7 +7,7 @@ from loguru import logger
 
 class cache:
     def __init__(self):
-        self.root = Path.home() / ".cache" / "manga-ocr"
+        self.root = (os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "manga-ocr"
         self.root.mkdir(parents=True, exist_ok=True)
 
     @property

--- a/mokuro/cache.py
+++ b/mokuro/cache.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 class cache:
     def __init__(self):
-        self.root = (os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "manga-ocr"
+        self.root = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "manga-ocr"
         self.root.mkdir(parents=True, exist_ok=True)
 
     @property

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,87 @@
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mokuro.cache as cache_module
+
+
+def _new_instance(tmp_path):
+    """Create a cache instance with root in tmp_path, bypassing __init__ side effects."""
+    CacheClass = type(cache_module.cache)
+    instance = CacheClass.__new__(CacheClass)
+    instance.root = tmp_path / "manga-ocr"
+    instance.root.mkdir(parents=True, exist_ok=True)
+    return instance
+
+
+class TestCacheInit:
+    def test_root_falls_back_to_home_when_xdg_not_set(self, tmp_path):
+        CacheClass = type(cache_module.cache)
+        env = {k: v for k, v in os.environ.items() if k != "XDG_CACHE_HOME"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("pathlib.Path.home", return_value=tmp_path):
+                instance = CacheClass()
+        assert instance.root == tmp_path / ".cache" / "manga-ocr"
+
+    def test_root_uses_xdg_cache_home_when_set(self, tmp_path):
+        CacheClass = type(cache_module.cache)
+        with patch.dict(os.environ, {"XDG_CACHE_HOME": str(tmp_path)}):
+            instance = CacheClass()
+        assert instance.root == tmp_path / "manga-ocr"
+
+    def test_root_dir_created_on_init(self, tmp_path):
+        subdir = tmp_path / "cache_dir"
+        CacheClass = type(cache_module.cache)
+        env = {k: v for k, v in os.environ.items() if k != "XDG_CACHE_HOME"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("pathlib.Path.home", return_value=subdir):
+                instance = CacheClass()
+        assert instance.root.is_dir()
+
+
+class TestDownloadIfNeeded:
+    def test_no_download_when_file_exists(self, tmp_path):
+        instance = _new_instance(tmp_path)
+        file_path = instance.root / "test.pt"
+        file_path.touch()
+
+        with patch("mokuro.cache.requests.get") as mock_get:
+            instance._download_if_needed(file_path, "http://example.com/test.pt")
+
+        mock_get.assert_not_called()
+
+    def test_downloads_when_file_missing(self, tmp_path):
+        instance = _new_instance(tmp_path)
+        file_path = instance.root / "test.pt"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.iter_content.return_value = [b"chunk1", b"chunk2"]
+
+        with patch("mokuro.cache.requests.get", return_value=mock_response) as mock_get:
+            instance._download_if_needed(file_path, "http://example.com/test.pt")
+
+        mock_get.assert_called_once_with("http://example.com/test.pt", stream=True, verify=True)
+        assert file_path.read_bytes() == b"chunk1chunk2"
+
+    def test_raises_on_non_200_response(self, tmp_path):
+        instance = _new_instance(tmp_path)
+        file_path = instance.root / "test.pt"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("mokuro.cache.requests.get", return_value=mock_response):
+            with pytest.raises(RuntimeError, match="Failed downloading"):
+                instance._download_if_needed(file_path, "http://example.com/test.pt")
+
+
+class TestComicTextDetector:
+    def test_returns_correct_path(self, tmp_path):
+        instance = _new_instance(tmp_path)
+        expected_path = instance.root / "comictextdetector.pt"
+        expected_path.touch()
+
+        assert instance.comic_text_detector == expected_path


### PR DESCRIPTION
# Summary
One line change to update the cache directory to respect the `$XDG_CACHE_HOME` environment variable, falling back to `~/.cache` when unset — aligning with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
As someone who has set a custom path for this, it is very annoying when all other apps follow it but mokuro does not.
 
# What changed
In `mokuro/cache.py`, the cache root was previously hardcoded to `~/.cache/manga-ocr`. It now checks `$XDG_CACHE_HOME` first:

## Before
```
self.root = Path.home() / ".cache" / "manga-ocr"
```

## After
```
self.root = (os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "manga-ocr"
```

# What is the XDG Base Directory Specification?
The XDG Base Directory Specification (https://specifications.freedesktop.org/basedir-spec/latest/) is a freedesktop.org standard that defines where applications should store their cache, config, data, and state files on Linux and other Unix-like systems using environment variables.
When `$XDG_CACHE_HOME` is not set, the spec mandates a default of `$HOME/.cache` - which is exactly the fallback behavior implemented here.

## Relevant links:
- XDG Base Directory Specification (latest) (https://specifications.freedesktop.org/basedir-spec/latest/)
- Arch Wiki: XDG Base Directory (https://wiki.archlinux.org/title/XDG_Base_Directory)

## Impact
- No breaking change - users who haven't set `$XDG_CACHE_HOME` see identical behavior (`~/.cache/manga-ocr`).
- Users who have configured `$XDG_CACHE_HOME` will now have mokuro's cache placed in the correct location.
