### PR TITLE
Pin setuptools to latest compatible version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See also:
 
 # Installation
 
-You need Python 3.6 or newer. Please note, that the newest Python release might not be supported due to a PyTorch dependency, 
+You need Python 3.10 or newer. Please note, that the newest Python release might not be supported due to a PyTorch dependency, 
 which often breaks with new Python releases and needs some time to catch up.
 Refer to [PyTorch website](https://pytorch.org/get-started/locally/) for a list of supported Python versions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 ]
 description = "Browser reader for manga with selectable text"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -23,7 +23,7 @@ dependencies = [
     "pyclipper",
     "requests",
     "scipy",
-    "setuptools",
+    "setuptools<81",
     "shapely",
     "torch>=1.7.0",
     "torchsummary",


### PR DESCRIPTION
Some mokuro installations no longer work because mokuro is incompatible with setuptools >= 82 (pkg_resources was removed).

As a workaround, this commit pins the setuptools dependency to <81. There is probably a better long term solution.

I also found that I could not install with `requires-python = ">=3.6"`. It needed to be increased to at least 3.7, but I changed it to 3.10 because that is currently the lowest version supported by Python. PyTorch also currently recommends Python 3.10-3.14.

I did a basic manual test of this on MacOS (installed successfully and processed some manga).

I believe this fixes #153.
